### PR TITLE
Fix line endings for shell-scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Configure line ending normalisation for this repository.
+# See http://schacon.github.io/git/gitattributes.html for more information.
+#
+# Also each developer should configure the old style normalisation on her workstation
+# (see http://timclem.wordpress.com/2012/03/01/mind-the-end-of-your-line/):
+#
+# Windows user should use: git config --global core.autocrlf true
+# Unix/Linux users should use: git config --global core.autocrlf input
+
+# Auto detect text files and perform LF normalization
+# Shell scripts require LF
+*.sh    text eol=lf


### PR DESCRIPTION
When the repository is checked out on Windows, shell-scripts must not have CRLF line endings, otherwise they are not executed properly.